### PR TITLE
Reshaped xarray resampled output

### DIFF
--- a/s2s/time.py
+++ b/s2s/time.py
@@ -326,6 +326,16 @@ class AdventCalendar:
         bins = bins.assign_coords(
             {"anchor_year": bins["anchor_year"], "i_interval": bins["i_interval"]}
         )
+        # Also make the intervals themselves a coordinate so they are not lost when
+        #   grabbing a variable from the resampled dataset.
+        bins = bins.set_coords('interval')
+
+        # Reshaping the dataset to have the anchor_year and i_interval as dimensions.
+        #   set anchor_year or i_interval as the main dimension
+        #   (otherwise index is kept as dimension)
+        bins = bins.swap_dims({'index': 'anchor_year'})
+        bins = bins.set_index(ai=('anchor_year', 'i_interval'))
+        bins = bins.unstack()
 
         return bins
 

--- a/s2s/time.py
+++ b/s2s/time.py
@@ -336,6 +336,7 @@ class AdventCalendar:
         bins = bins.swap_dims({'index': 'anchor_year'})
         bins = bins.set_index(ai=('anchor_year', 'i_interval'))
         bins = bins.unstack()
+        bins = bins.transpose("anchor_year", "i_interval", ...)
 
         return bins
 

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -262,13 +262,13 @@ class TestResample:
     def test_dataarray(self, dummy_calendar, dummy_dataarray):
         da, expected = dummy_dataarray
         resampled_data = dummy_calendar.resample(da)
-        testing_vals = resampled_data["data1"].isel(index=range(2))
+        testing_vals = resampled_data["data1"].isel(anchor_year=0)
         np.testing.assert_allclose(testing_vals, expected)
 
     def test_dataset(self, dummy_calendar, dummy_dataset):
         ds, expected = dummy_dataset
         resampled_data = dummy_calendar.resample(ds)
-        testing_vals = resampled_data["data1"].isel(index=range(2))
+        testing_vals = resampled_data["data1"].isel(anchor_year=0)
         np.testing.assert_allclose(testing_vals, expected)
 
     def test_missing_time_dim(self, dummy_calendar, dummy_dataset):


### PR DESCRIPTION
Implements the suggested changes from #34: Make the intervals a coordinate, and turn the anchor_year and i_interval into dimensions.

The xarray output of resample now has the following form:
```python
<xarray.Dataset>
Dimensions:      (anchor_year: 2, i_interval: 3)
Coordinates:
    index        (anchor_year, i_interval) int64 0 1 2 3 4 5
    interval     (anchor_year, i_interval) object (2020-01-31, 2020-05-10] .....
  * anchor_year  (anchor_year) int64 2020 2021
  * i_interval   (i_interval) int64 0 1 2
Data variables:
    data         (anchor_year, i_interval) float64 0.9239 0.5934 ... 0.4805
```