### PR TITLE
Add mypy

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,10 +45,10 @@ jobs:
       fail-fast: false
     steps:
       - uses: actions/checkout@v3
-      - name: Set up Python 3.9
+      - name: Set up Python 3.10
         uses: actions/setup-python@v3
         with:
-          python-version: 3.9
+          python-version: 3.10
       - name: Python info
         shell: bash -l {0}
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,6 +54,8 @@ jobs:
         run: |
           which python3
           python3 --version
+      - name: Run mypy in isolation
+        run: mypy s2spy --ignore-missing-imports
       - name: Upgrade pip and install dependencies
         run: |
           python3 -m pip install --upgrade pip setuptools

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,8 +54,6 @@ jobs:
         run: |
           which python3
           python3 --version
-      - name: Run mypy in isolation
-        run: mypy s2spy --ignore-missing-imports
       - name: Upgrade pip and install dependencies
         run: |
           python3 -m pip install --upgrade pip setuptools

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Set up Python 3.10
         uses: actions/setup-python@v3
         with:
-          python-version: 3.10
+          python-version: "3.10"
       - name: Python info
         shell: bash -l {0}
         run: |

--- a/.github/workflows/sonarcloud.yml
+++ b/.github/workflows/sonarcloud.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Set up Python
         uses: actions/setup-python@v3
         with:
-          python-version: 3.9
+          python-version: "3.10"
       - name: Python info
         shell: bash -l {0}
         run: |

--- a/.prospector.yml
+++ b/.prospector.yml
@@ -11,6 +11,7 @@ member-warnings: false
 
 ignore-paths:
   - docs
+  - build
 
 pyroma:
     run: true

--- a/.prospector.yml
+++ b/.prospector.yml
@@ -32,3 +32,9 @@ pyflakes:
     disable: [
         F401,  # unused import: already checked by pylint
     ]
+
+mypy:
+    # see https://github.com/PyCQA/prospector/issues/313
+    run: true
+    options:
+        ignore-missing-imports: true

--- a/s2spy/__init__.py
+++ b/s2spy/__init__.py
@@ -16,3 +16,5 @@ logging.getLogger(__name__).addHandler(logging.NullHandler())
 __author__ = "Yang Liu"
 __email__ = "y.liu@esciencecenter.nl"
 __version__ = "0.1.0"
+
+__all__ = ["dimensionality", "time", "traintest", "RGDR"]

--- a/setup.cfg
+++ b/setup.cfg
@@ -47,15 +47,16 @@ install_requires =
 dev =
     bump2version
     coverage [toml]
-    prospector[with_pyroma]
     isort
+    mypy
+    myst_parser
+    prospector[with_pyroma]
     pytest
     pytest-cov
     sphinx
     sphinx_rtd_theme
     sphinx-autoapi
     tox
-    myst_parser
 publishing =
     twine
     wheel


### PR DESCRIPTION
Added to Prospector or run as standalone:

```
# in root dir
prospector

# or
mypy s2spy --ignore-missing-imports
```

This PR also updates the python version for GH actions to 3.10, for there have been substantial improvements in the type hint system recently.

Note: some broken types will be superseded by #60 