### PR TITLE
reinitialization issue fixed and warning when traintest split is updated

### DIFF
--- a/s2spy/traintest.py
+++ b/s2spy/traintest.py
@@ -67,7 +67,15 @@ def _split_dataset(splitter, data, key):
         split_data[i, train_indices] = "train"
         split_data[i, test_indices] = "test"
 
-    data.expand_dims("split")
+    if 'split' not in data.dims:
+        data.expand_dims("split")
+        
+    if 'traintest' in data.coords:
+        identical = np.char.equal(data['traintest'].values, split_data).all()
+        if identical==False:
+            print('Traintest split was already present in data and unequal to '
+                  'newly generated split, Traintest split has been updated.')
+        
     data["split"] = np.arange(split_data.shape[0])
     data["traintest"] = (["split", key], split_data)
     data = data.set_coords("traintest")

--- a/s2spy/traintest.py
+++ b/s2spy/traintest.py
@@ -72,9 +72,9 @@ def _split_dataset(splitter, data, key):
         
     if 'traintest' in data.coords:
         identical = np.char.equal(data['traintest'].values, split_data).all()
-        if identical==False:
+        if identical is False:
             print('Traintest split was already present in data and unequal to '
-                  'newly generated split, Traintest split has been updated.')
+                  'newly generated split, traintest split has been updated.')
         
     data["split"] = np.arange(split_data.shape[0])
     data["traintest"] = (["split", key], split_data)

--- a/s2spy/traintest.py
+++ b/s2spy/traintest.py
@@ -72,7 +72,7 @@ def _split_dataset(splitter, data, key):
         
     if 'traintest' in data.coords:
         identical = np.char.equal(data['traintest'].values, split_data).all()
-        if identical is False:
+        if not identical:
             print('Traintest split was already present in data and unequal to '
                   'newly generated split, traintest split has been updated.')
         


### PR DESCRIPTION
Proposed solution for issue #87. 

Solves the issue when dimension 'split' already exists in data. 

Checks if existing traintest split is unequal to newly generated traintest split and communicates (print statement) when traintest split is updated. 