### PR TITLE
Added input checks and tests for anchor kwarg

### DIFF
--- a/s2spy/_base_calendar.py
+++ b/s2spy/_base_calendar.py
@@ -72,12 +72,16 @@ class BaseCalendar(ABC):
             raise ValueError("Anchor input must be a string with expected format.")
         # format match
         if re.fullmatch("\\d{1,2}-\\d{1,2}", anchor_str):
+            utils.check_month_day(*[int(x) for x in anchor_str.split("-")])
             fmt = "%m-%d"
         elif re.fullmatch("\\d{1,2}", anchor_str):
+            utils.check_month_day(int(anchor_str))
             fmt = "%m"
         elif re.fullmatch("W\\d{1,2}-\\d", anchor_str):
+            utils.check_week_day(*[int(x) for x in anchor_str[1:].split("-")])
             fmt = "W%W-%w"
         elif re.fullmatch("W\\d{1,2}", anchor_str):
+            utils.check_week_day(int(anchor_str[1:]))
             fmt = "W%W-%w"
             anchor_str += "-1"
         elif anchor_str.lower() in utils.get_month_names():
@@ -382,7 +386,7 @@ class Period(ABC):
     """Basic construction element of calendar for defining target period."""
 
     def __init__(self, length: str, gap: str = "0d") -> None:
-        
+
         self._length = DateOffset(**self._parse_time(length))
         self._gap = DateOffset(**self._parse_time(gap))
         self._target = False

--- a/s2spy/utils.py
+++ b/s2spy/utils.py
@@ -169,3 +169,54 @@ def get_month_names() -> Dict:
         "nov": 11,
         "dec": 12,
     }
+
+
+def check_month_day(month: int, day: int = 1):
+    """Checks if the input day/month combination is valid.
+
+    Months must be between 1 and 12, and days must be within 1 and 28/30/31 (depending
+    on the month).
+
+    Args:
+        month: Month number
+        day: Day number. Defaults to 1.
+    """
+
+    if month in {1, 3, 5, 7, 8, 10, 12}:
+        if (day < 1) or (day > 31):
+            raise ValueError(
+                "Incorrect anchor input. "
+                f"Day number {day} is not a valid day for month {month}"
+            )
+    elif month in {4, 6, 9}:
+        if (day < 1) or (day > 30):
+            raise ValueError(
+                "Incorrect anchor input. "
+                f"Day number {day} is not a valid day for month {month}"
+            )
+    elif month == 2:
+        if (day < 1) or (day > 28):
+            raise ValueError(
+                "Incorrect anchor input. "
+                f"Day number {day} is not a valid day for month {month}"
+            )
+    else:
+        raise ValueError(
+            "Incorrect anchor input. Month number must be between 1 and 12."
+        )
+
+
+def check_week_day(week: int, day: int = 1):
+    if week == 53:
+        raise ValueError(
+            "Incorrect anchor input. "
+            "Week 53 is not a valid input, as not every year contains a 53rd week."
+        )
+    if (week < 1) or (week > 52):
+        raise ValueError(
+            "Incorrect anchor input. Week numbers must be between 1 and 52."
+        )
+    if (day < 1) or (day > 7):
+        raise ValueError(
+            "Incorrect anchor input. Weekday numbers must be between 1 and 7."
+        )

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -366,6 +366,10 @@ class TestAnchorKwarg:
         "W01-8",  # Weekday greater than 7 (Sunday)
         "w12",  # Small letter `w`.
         "juli",  # Non-English month name
+        "July 5",  # Month name + day
+        "July-5",
+        "jan 20",
+        "jan-20",
     )
 
     @pytest.mark.parametrize("test_input, expected_fmt, expected_str", correct_inputs)

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -336,12 +336,14 @@ class TestMap:
 class TestAnchorKwarg:
     correct_inputs = [  # format: (anchor, anchor_fmt, anchor_str)
         ("5-5", "%m-%d", "5-5"),
-        ("05-5", "%m-%d", "05-5"),
-        ("05-05", "%m-%d", "05-05"),
+        ("02-5", "%m-%d", "02-5"),
+        ("06-05", "%m-%d", "06-05"),
         ("5-05", "%m-%d", "5-05"),
         ("12-31", "%m-%d", "12-31"),
         ("W01", "W%W-%w", "W01-1"),
         ("W9", "W%W-%w", "W9-1"),
+        ("W01-4", "W%W-%w", "W01-4"),
+        ("W9-1", "W%W-%w", "W9-1"),
         ("December", "%m", "12"),
         ("dec", "%m", "12"),
         ("jan", "%m", "1"),
@@ -356,6 +358,8 @@ class TestAnchorKwarg:
         "12-0",  # day number less than 1
         "12-32",  # day number greater than 31
         "31-12",  # incorrect month/day order
+        "4-31",  # 31 April (nonexistant date)
+        "2-29",  # 29 February (doesn't exist in every year)
         "W60",  # Week number greater than 52 (only some years have 53 weeks)
         "W53",
         "W01-0",  # Weekday smaller than 1 (Monday)

--- a/tests/test_time.py
+++ b/tests/test_time.py
@@ -331,3 +331,46 @@ class TestMap:
             calendar.get_intervals().index.values, expected_index
         )
         assert calendar.get_intervals().iloc[0].size == expected_size
+
+
+class TestAnchorKwarg:
+    correct_inputs = [  # format: (anchor, anchor_fmt, anchor_str)
+        ("5-5", "%m-%d", "5-5"),
+        ("05-5", "%m-%d", "05-5"),
+        ("05-05", "%m-%d", "05-05"),
+        ("5-05", "%m-%d", "5-05"),
+        ("12-31", "%m-%d", "12-31"),
+        ("W01", "W%W-%w", "W01-1"),
+        ("W9", "W%W-%w", "W9-1"),
+        ("December", "%m", "12"),
+        ("dec", "%m", "12"),
+        ("jan", "%m", "1"),
+        ("Jan", "%m", "1"),
+    ]
+
+    incorrect_inputs = (
+        10,  # non-str inputs
+        (1, 2),
+        "0",  # month number less than 1
+        "13",  # month number greater than 12
+        "12-0",  # day number less than 1
+        "12-32",  # day number greater than 31
+        "31-12",  # incorrect month/day order
+        "W60",  # Week number greater than 52 (only some years have 53 weeks)
+        "W53",
+        "W01-0",  # Weekday smaller than 1 (Monday)
+        "W01-8",  # Weekday greater than 7 (Sunday)
+        "w12",  # Small letter `w`.
+        "juli",  # Non-English month name
+    )
+
+    @pytest.mark.parametrize("test_input, expected_fmt, expected_str", correct_inputs)
+    def test_correct_anchor_input(self, test_input, expected_fmt, expected_str):
+        cal = AdventCalendar(anchor=test_input)
+        assert cal._anchor_fmt == expected_fmt  # pylint: disable=protected-access
+        assert cal._anchor == expected_str  # pylint: disable=protected-access
+
+    @pytest.mark.parametrize("test_input", incorrect_inputs)
+    def test_incorrect_anchor_input(self, test_input):
+        with pytest.raises(ValueError):
+            _ = AdventCalendar(anchor=test_input)


### PR DESCRIPTION
This PR adds tests for the anchor keyword argument of the BaseCalendar (and thus its children). The test tests for a set of correct inputs, and also a set of incorrect inputs that should be rejected.

Based on the tests, checks were added to the anchor parser, to make sure that all month-day and week-weekday inputs are valid. (E.g. no 31st of April)