### PR TITLE
Adding the `n` kwarg to the calendar's `add_intervals` method

### DIFF
--- a/notebooks/all_about_the_calendar.ipynb
+++ b/notebooks/all_about_the_calendar.ipynb
@@ -59,7 +59,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "To this calendar we can add an interval, in this case a \"target\" interval which we want to use as our target data:"
+    "To this calendar we can add an interval, in this case a \"target\" interval which we want to use as our target data.\n",
+    "\n",
+    "Note that when calling `add_intervals`, the default `n` (number of intervals) is 1."
    ]
   },
   {
@@ -68,7 +70,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cal.add_interval(\"target\", length=\"1d\")"
+    "cal.add_intervals(\"target\", length=\"1d\")"
    ]
   },
   {
@@ -319,7 +321,7 @@
     }
    ],
    "source": [
-    "cal.add_interval(\"precursor\", length=\"1d\", n=6)\n",
+    "cal.add_intervals(\"precursor\", length=\"1d\", n=6)\n",
     "cal.show()"
    ]
   },
@@ -369,7 +371,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "cal.add_interval(\"precursor\", length=\"1M\", n=2)"
+    "cal.add_intervals(\"precursor\", length=\"1M\", n=2)"
    ]
   },
   {
@@ -429,7 +431,7 @@
     }
    ],
    "source": [
-    "cal.add_interval(\"precursor\", length=\"1M\", gap=\"1M\")\n",
+    "cal.add_intervals(\"precursor\", length=\"1M\", gap=\"1M\")\n",
     "cal.visualize(n_years=1, add_legend=False, show_length=True)"
    ]
   },
@@ -460,7 +462,7 @@
     }
    ],
    "source": [
-    "cal.add_interval(\"precursor\", length=\"1M\", gap=\"-2W\")\n",
+    "cal.add_intervals(\"precursor\", length=\"1M\", gap=\"-2W\")\n",
     "cal.visualize(n_years=1, add_legend=False, show_length=True)"
    ]
   },
@@ -500,8 +502,8 @@
    "source": [
     "cal = s2spy.time.Calendar(\"06-01\") \n",
     "cal.map_years(2020, 2022)\n",
-    "cal.add_interval(\"target\", \"1d\")\n",
-    "cal.add_interval(\"precursor\", \"7d\", \"1M\")\n",
+    "cal.add_intervals(\"target\", \"1d\")\n",
+    "cal.add_intervals(\"precursor\", \"7d\", \"1M\")\n",
     "cal"
    ]
   },
@@ -731,8 +733,8 @@
    ],
    "source": [
     "cal = Calendar(anchor=\"December\")  # [December 01)\n",
-    "cal.add_interval(\"target\", \"1M\")\n",
-    "cal.add_interval(\"precursor\", \"1M\", n=11)\n",
+    "cal.add_intervals(\"target\", \"1M\")\n",
+    "cal.add_intervals(\"precursor\", \"1M\", n=11)\n",
     "cal.map_years(2022, 2022)\n",
     "cal.show()"
    ]
@@ -828,8 +830,8 @@
    "source": [
     "Calendar(anchor=\"W12\")  # Week 12\n",
     "cal = Calendar(anchor=\"W12-5\")  # Friday on week 12\n",
-    "cal.add_interval(\"target\", \"1d\")\n",
-    "cal.add_interval(\"precursor\", \"1d\", gap=\"1W\")\n",
+    "cal.add_intervals(\"target\", \"1d\")\n",
+    "cal.add_intervals(\"precursor\", \"1d\", gap=\"1W\")\n",
     "cal.map_years(2018, 2022)\n",
     "cal.show()"
    ]

--- a/notebooks/all_about_the_calendar.ipynb
+++ b/notebooks/all_about_the_calendar.ipynb
@@ -216,7 +216,9 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "We can add some precursor periods, and inspect the table again. Note that the target interval has a positive index, while the precursors have negative indices."
+    "We can add some precursor periods, and inspect the table again. We can add multiple intervals using the `n` keyword argument.\n",
+    "\n",
+    "Note that the target interval has a positive index, while the precursors have negative indices."
    ]
   },
   {
@@ -317,8 +319,7 @@
     }
    ],
    "source": [
-    "for _ in range(6):\n",
-    "    cal.add_interval(\"precursor\", length=\"1d\")\n",
+    "cal.add_interval(\"precursor\", length=\"1d\", n=6)\n",
     "cal.show()"
    ]
   },
@@ -368,8 +369,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "for _ in  range(2):\n",
-    "    cal.add_interval(\"precursor\", length=\"1M\")"
+    "cal.add_interval(\"precursor\", length=\"1M\", n=2)"
    ]
   },
   {
@@ -732,8 +732,7 @@
    "source": [
     "cal = Calendar(anchor=\"December\")  # [December 01)\n",
     "cal.add_interval(\"target\", \"1M\")\n",
-    "for _ in range(11):\n",
-    "    cal.add_interval(\"precursor\", \"1M\")\n",
+    "cal.add_interval(\"precursor\", \"1M\", n=11)\n",
     "cal.map_years(2022, 2022)\n",
     "cal.show()"
    ]

--- a/notebooks/tutorial_alternative_calendars.ipynb
+++ b/notebooks/tutorial_alternative_calendars.ipynb
@@ -408,13 +408,13 @@
    "outputs": [],
    "source": [
     "# add target periods\n",
-    "calendar.add_interval(\"target\", length=\"20d\")\n",
-    "calendar.add_interval(\"target\", length=\"20d\", gap=\"10d\")  # You can add gaps between intervals\n",
+    "calendar.add_intervals(\"target\", length=\"20d\")\n",
+    "calendar.add_intervals(\"target\", length=\"20d\", gap=\"10d\")  # You can add gaps between intervals\n",
     "\n",
     "# add precursor periods\n",
-    "calendar.add_interval(\"precursor\", \"10d\", \"-5d\")  # The gap can be negative, leading to overlap\n",
-    "calendar.add_interval(\"precursor\", \"2W\")  # Lengths can also be weeks, or months\n",
-    "calendar.add_interval(\"precursor\", \"1M\")"
+    "calendar.add_intervals(\"precursor\", \"10d\", \"-5d\")  # The gap can be negative, leading to overlap\n",
+    "calendar.add_intervals(\"precursor\", \"2W\")  # Lengths can also be weeks, or months\n",
+    "calendar.add_intervals(\"precursor\", \"1M\")"
    ]
   },
   {

--- a/s2spy/time.py
+++ b/s2spy/time.py
@@ -517,18 +517,30 @@ class Calendar(BaseCalendar):
         role: Literal["target", "precursor"],
         length: str,
         gap: str = "0d",
+        n: int = 1,
     ) -> None:
-        """Add an interval to the calendar. The interval can be a target or a precursor.
+        """Add one or more intervals to the calendar. The interval can be a target or a
+        precursor.
 
         Args:
-            role: Either a 'target' or 'precursor' interval.
-            length: The length of the interval, in a format of '5d' for five days, '2W'
+            role: Either a 'target' or 'precursor' interval(s).
+            length: The length of the interval(s), in a format of '5d' for five days, '2W'
                 for two weeks, or '1M' for one month.
             gap: The gap between this interval and the preceding target/precursor
                 interval. Same format as the length argument.
+            n: The number of intervals which should be added to the calendar. Defaults
+                to 1.
         """
+        if not isinstance(n, int):
+            raise ValueError("Please input an 'int' type for the 'n' argument."
+                             f" Not a {type(n)}.")
+        if n <= 0:
+            raise ValueError("The number of intervals 'n' has to be 1 or greater, "
+                             f"not '{n}'.")
+
         if role in ["target", "precursor"]:
-            self._append(Interval(role, length, gap))
+            for _ in range(n):
+                self._append(Interval(role, length, gap))
         else:
             raise ValueError(
                 f"Type '{role}' is not a valid interval type. Please "

--- a/s2spy/time.py
+++ b/s2spy/time.py
@@ -512,7 +512,7 @@ class Calendar(BaseCalendar):
     def n_targets(self):
         return len(self.targets)
 
-    def add_interval(
+    def add_intervals(
         self,
         role: Literal["target", "precursor"],
         length: str,

--- a/s2spy/time.py
+++ b/s2spy/time.py
@@ -519,8 +519,10 @@ class Calendar(BaseCalendar):
         gap: str = "0d",
         n: int = 1,
     ) -> None:
-        """Add one or more intervals to the calendar. The interval can be a target or a
-        precursor.
+        """Add one or more intervals to the calendar.
+
+        The interval can be a target or a precursor, and can be defined by its length,
+        a possible gap between this interval and the preceding interval.
 
         Args:
             role: Either a 'target' or 'precursor' interval(s).

--- a/tests/test_custom_calendar.py
+++ b/tests/test_custom_calendar.py
@@ -64,8 +64,8 @@ class TestCalendar:
     def dummy_calendar(self):
         cal = Calendar(anchor="12-31")
         # append building blocks
-        cal.add_interval("target", "20d")
-        cal.add_interval("precursor", "10d")
+        cal.add_intervals("target", "20d")
+        cal.add_intervals("precursor", "10d")
         # map years
         cal = cal.map_years(2021, 2021)
         return cal
@@ -88,7 +88,7 @@ class TestCalendar:
 
     def test_repr_reproducible(self):
         cal = Calendar(anchor="12-31", allow_overlap=True)
-        cal.add_interval("target", "10d")
+        cal.add_intervals("target", "10d")
         cal.map_years(2020, 2022)
         repr_dict = eval(repr(cal)).__dict__  # pylint: disable=eval-used
         assert repr_dict["_anchor"] == "12-31"
@@ -118,8 +118,8 @@ class TestCalendar:
         )
         assert np.array_equal(dummy_calendar.flat, expected)
 
-    def test_add_interval(self, dummy_calendar):
-        dummy_calendar.add_interval("target", "30d")
+    def test_add_intervals(self, dummy_calendar):
+        dummy_calendar.add_intervals("target", "30d")
         dummy_calendar = dummy_calendar.map_years(2021, 2021)
         expected = np.array(
             [interval("2021-12-21", "2021-12-31", closed="left"),
@@ -128,8 +128,8 @@ class TestCalendar:
         )
         assert np.array_equal(dummy_calendar.flat, expected)
 
-    def test_add_interval_multiple(self, dummy_calendar):
-        dummy_calendar.add_interval("target", "30d", n=2)
+    def test_add_intervals_multiple(self, dummy_calendar):
+        dummy_calendar.add_intervals("target", "30d", n=2)
         dummy_calendar = dummy_calendar.map_years(2021, 2021)
         expected = np.array(
             [interval("2021-12-21", "2021-12-31", closed="left"),
@@ -140,12 +140,12 @@ class TestCalendar:
         assert np.array_equal(dummy_calendar.flat, expected)
 
     @pytest.mark.parametrize("incorrect_n", (2.0, [1], 0, -10))  # non-int or <=0.
-    def test_add_interval_incorrect_n(self, dummy_calendar, incorrect_n):
+    def test_add_intervals_incorrect_n(self, dummy_calendar, incorrect_n):
         with pytest.raises(ValueError):
-            dummy_calendar.add_interval("target", "30d", n=incorrect_n)
+            dummy_calendar.add_intervals("target", "30d", n=incorrect_n)
 
     def test_gap_intervals(self, dummy_calendar):
-        dummy_calendar.add_interval("target", "20d", gap="10d")
+        dummy_calendar.add_intervals("target", "20d", gap="10d")
         dummy_calendar = dummy_calendar.map_years(2021, 2021)
         expected = np.array(
             [interval("2021-12-21", "2021-12-31", closed="left"),
@@ -155,7 +155,7 @@ class TestCalendar:
         assert np.array_equal(dummy_calendar.flat, expected)
 
     def test_overlap_intervals(self, dummy_calendar):
-        dummy_calendar.add_interval("precursor", "10d", gap="-5d")
+        dummy_calendar.add_intervals("precursor", "10d", gap="-5d")
         dummy_calendar = dummy_calendar.map_years(2021, 2021)
         expected = np.array(
             [interval("2021-12-16", "2021-12-26", closed="left"),
@@ -181,8 +181,8 @@ class TestCalendar:
 
     def test_non_day_interval_length(self):
         cal = Calendar(anchor="December")
-        cal.add_interval("target", "1M")
-        cal.add_interval("precursor", "10M")
+        cal.add_intervals("target", "1M")
+        cal.add_intervals("precursor", "10M")
         cal.map_years(2020, 2020)
         expected = np.array(
             [interval("2020-02-01", "2020-12-01", closed="left"),
@@ -195,8 +195,8 @@ class TestCalendar:
                               (False, [2022, 2020])))
     def test_allow_overlap(self, allow_overlap, expected_anchors):
         cal = Calendar(anchor="12-31", allow_overlap=allow_overlap)
-        cal.add_interval("target", length="30d")
-        cal.add_interval("precursor", length="365d")
+        cal.add_intervals("target", length="30d")
+        cal.add_intervals("precursor", length="365d")
         cal.map_years(2020, 2022)
         assert np.array_equal(
             expected_anchors,

--- a/tests/test_custom_calendar.py
+++ b/tests/test_custom_calendar.py
@@ -118,7 +118,7 @@ class TestCalendar:
         )
         assert np.array_equal(dummy_calendar.flat, expected)
 
-    def test_append(self, dummy_calendar):
+    def test_add_interval(self, dummy_calendar):
         dummy_calendar.add_interval("target", "30d")
         dummy_calendar = dummy_calendar.map_years(2021, 2021)
         expected = np.array(
@@ -127,6 +127,22 @@ class TestCalendar:
              interval("2022-01-20", "2022-02-19", closed="left"),]
         )
         assert np.array_equal(dummy_calendar.flat, expected)
+
+    def test_add_interval_multiple(self, dummy_calendar):
+        dummy_calendar.add_interval("target", "30d", n=2)
+        dummy_calendar = dummy_calendar.map_years(2021, 2021)
+        expected = np.array(
+            [interval("2021-12-21", "2021-12-31", closed="left"),
+             interval("2021-12-31", "2022-01-20", closed="left"),
+             interval("2022-01-20", "2022-02-19", closed="left"),
+             interval("2022-02-19", "2022-03-21", closed="left"),]
+        )
+        assert np.array_equal(dummy_calendar.flat, expected)
+
+    @pytest.mark.parametrize("incorrect_n", (2.0, [1], 0, -10))  # non-int or <=0.
+    def test_add_interval_incorrect_n(self, dummy_calendar, incorrect_n):
+        with pytest.raises(ValueError):
+            dummy_calendar.add_interval("target", "30d", n=incorrect_n)
 
     def test_gap_intervals(self, dummy_calendar):
         dummy_calendar.add_interval("target", "20d", gap="10d")

--- a/tests/test_plots.py
+++ b/tests/test_plots.py
@@ -13,9 +13,9 @@ class TestPlots:
         bokeh_io.output_file(tmp_path / "test.html")
 
     custom_cal_pre = time.Calendar(anchor="12-31")
-    custom_cal_pre.add_interval("precursor", "10d")
+    custom_cal_pre.add_intervals("precursor", "10d")
     custom_cal_tar = time.Calendar(anchor="12-31")
-    custom_cal_tar.add_interval("target", "10d")
+    custom_cal_tar.add_intervals("target", "10d")
 
     calendars = [
         time.AdventCalendar(anchor="12-31", freq="60d"),

--- a/tests/test_resample.py
+++ b/tests/test_resample.py
@@ -199,9 +199,9 @@ class TestResample:
         series = pd.Series(test_data, index=time_index, name="data1")
 
         calendar = Calendar(anchor="10-05")
-        calendar.add_interval("target", "60d")
-        calendar.add_interval("precursor", "60d")
-        calendar.add_interval("precursor", "60d", gap="-60d")
+        calendar.add_intervals("target", "60d")
+        calendar.add_intervals("precursor", "60d")
+        calendar.add_intervals("precursor", "60d", gap="-60d")
 
         calendar.map_to_data(series)
         resampled_data = resample(calendar, series)


### PR DESCRIPTION
This PR adds the `n` kwarg to the add_interval method, allowing users to add multiple intervals at once, without a for loop.
For example:
```py
cal = Calendar(anchor="Jan")
cal.add_intervals("precursor", "1W", n=10)
```

Instead of the old way:
```py
cal = Calendar(anchor="Jan")
for _ in range(10):
    cal.add_intervals("precursor", "1W")
```

- `n` kwarg has been added and the docstring has been updated.
- `add_interval` is renamed to `add_intervals`
- The "all about the calendar" notebook has been updated to include the new syntax
- Tests have been added

Closes #147 