### PR TITLE
Align coords of trendline when passing data array 

### DIFF
--- a/s2spy/__init__.py
+++ b/s2spy/__init__.py
@@ -3,6 +3,7 @@
 This package is a high-level python package integrating expert knowledge
 and artificial intelligence to boost (sub) seasonal forecasting.
 """
+
 import logging
 from .rgdr.rgdr import RGDR
 

--- a/s2spy/preprocess.py
+++ b/s2spy/preprocess.py
@@ -254,9 +254,7 @@ class Preprocessor:
             Preprocessed data.
         """
         if dropna:
-            print("Dropping NaN values from data")
             data = data.dropna("time")
-            print(data)
 
         if not self._is_fit:
             raise ValueError(

--- a/s2spy/preprocess.py
+++ b/s2spy/preprocess.py
@@ -275,17 +275,18 @@ class Preprocessor:
         return d
 
     def fit_transform(
-        self, data: Union[xr.DataArray, xr.Dataset]
+        self, data: Union[xr.DataArray, xr.Dataset], dropna=False
     ) -> Union[xr.DataArray, xr.Dataset]:
         """Fit this Preprocessor to input data, and then apply the steps to the data.
 
         Args:
             data: Input data for fit and transform.
+            dropna: If True, drop all NaN values from the data before preprocessing.
 
         Returns:
             Preprocessed data.
         """
-        self.fit(data)
+        self.fit(data, dropna=dropna)
         return self.transform(data)
 
     @property

--- a/s2spy/preprocess.py
+++ b/s2spy/preprocess.py
@@ -215,6 +215,7 @@ class Preprocessor:
 
         Args:
             data: Input data for fitting.
+            dropna: If True, drop all NaN values from the data before preprocessing.
         """
         _check_input_data(data)
         if dropna:
@@ -249,6 +250,7 @@ class Preprocessor:
 
         Args:
             data: Input data to perform preprocessing.
+            dropna: If True, drop all NaN values from the data before preprocessing.
 
         Returns:
             Preprocessed data.

--- a/s2spy/preprocess.py
+++ b/s2spy/preprocess.py
@@ -1,4 +1,5 @@
 """Preprocessor for s2spy workflow."""
+
 import warnings
 from typing import Literal
 from typing import Union
@@ -73,17 +74,99 @@ def _trend_linear(
     return {"slope": slope, "intercept": intercept}
 
 
+def _get_lineartrend_timeseries(data: Union[xr.DataArray, xr.Dataset], trend: dict):
+    """Calculate the linear trend timeseries from the trend dictionary."""
+    trend_timeseries = trend["intercept"] + trend["slope"] * (
+        data["time"].astype(float)
+    )
+    return trend_timeseries.transpose(*data.dims)
+
+
+def _trend_poly(data: Union[xr.DataArray, xr.Dataset], degree: int = 2) -> dict:
+    """Calculate the polynomial trend over time and return coefficients.
+
+    Args:
+        data: Input data.
+        degree: Degree of the polynomial for detrending.
+
+    Returns:
+        Dictionary containing polynomial trend coefficients.
+    """
+    data.coords["ordinal_day"] = (
+        ("time",),
+        (data.time - data.time.min()).values.astype("timedelta64[D]").astype(int),
+    )
+    coeffs = data.swap_dims({"time": "ordinal_day"}).polyfit(
+        "ordinal_day", deg=degree, skipna=True
+    )
+    return {"coefficients": coeffs}
+
+
+def _get_polytrend_timeseries(data: Union[xr.DataArray, xr.Dataset], trend: dict):
+    data.coords["ordinal_day"] = (
+        ("time",),
+        (data.time - data.time.min()).values.astype("timedelta64[D]").astype(int),
+    )
+    polynomial_trend = xr.polyval(
+        data.swap_dims({"time": "ordinal_day"})["ordinal_day"], trend["coefficients"]
+    ).swap_dims({"ordinal_day": "time"})
+    # rename f"{data_var}_polyfit_coeffiencts" to orginal data_var name
+    if isinstance(data, xr.Dataset):
+        da_names = list(data.data_vars)
+        rename = dict(
+            map(
+                lambda i, j: (i, j),
+                list(polynomial_trend.data_vars),
+                da_names,
+            )
+        )
+        polynomial_trend = polynomial_trend.rename(rename)
+    if isinstance(
+        data, xr.DataArray
+    ):  # keep consistent with input data and _get_lineartrend_timeseries
+        polynomial_trend = polynomial_trend.to_array().squeeze("variable")
+        polynomial_trend.name = [
+            data.name if data.name is not None else "timeseries_polyfit"
+        ]
+    return polynomial_trend.transpose(*data.dims)
+
+
 def _subtract_linear_trend(data: Union[xr.DataArray, xr.Dataset], trend: dict):
     """Subtract a previously calclulated linear trend from (new) data."""
-    return data - trend["intercept"] - trend["slope"] * (data["time"].astype(float))
+    return data - _get_lineartrend_timeseries(data, trend)
+
+
+def _subtract_polynomial_trend(
+    data: Union[xr.DataArray, xr.Dataset],
+    trend: dict,
+):
+    """Subtract a previously calculated polynomial trend from (new) data.
+
+    Args:
+        data: The data from which to subtract the trend (either an xarray DataArray or Dataset).
+        trend: A dictionary containing the polynomial trend coefficients.
+
+    Returns:
+        The data with the polynomial trend subtracted.
+    """
+    # Subtract the polynomial trend from the data
+    return data - _get_polytrend_timeseries(data, trend)
 
 
 def _get_trend(
-    data: Union[xr.DataArray, xr.Dataset], method: str, nan_mask: str = "complete"
+    data: Union[xr.DataArray, xr.Dataset],
+    method: str,
+    nan_mask: str = "complete",
+    degree=2,
 ):
     """Calculate the trend, with a certain method. Only linear is implemented."""
     if method == "linear":
         return _trend_linear(data, nan_mask)
+
+    if method == "polynomial":
+        if nan_mask != "complete":
+            raise ValueError("Polynomial currently only supports 'complete' nan_mask")
+        return _trend_poly(data, degree)
     raise ValueError(f"Unkown detrending method '{method}'")
 
 
@@ -91,6 +174,8 @@ def _subtract_trend(data: Union[xr.DataArray, xr.Dataset], method: str, trend: d
     """Subtract the previously calculated trend from (new) data. Only linear is implemented."""
     if method == "linear":
         return _subtract_linear_trend(data, trend)
+    if method == "polynomial":
+        return _subtract_polynomial_trend(data, trend)
     raise NotImplementedError
 
 
@@ -227,8 +312,9 @@ class Preprocessor:
                 and end of the preprocessed data.
             subtract_climatology (optional): If you want to calculate and remove the
                 climatology of the data. Defaults to True.
-            detrend (optional): Which method to use for detrending. Currently the only method
-                supported is "linear". If you want to skip detrending, set this to None.
+            detrend (optional): Which method to use for detrending. Choose from "linear"
+                or "polynomial". Defaults to "linear". If you want to skip detrending,
+                set this to None.
             timescale: Temporal resolution of input data.
             nan_mask: How to handle NaN values. If 'complete', returns nan if x or y contains
                 1 or more NaN values. If 'individual', fit a trend by masking only the
@@ -317,6 +403,21 @@ class Preprocessor:
         """
         self.fit(data)
         return self.transform(data)
+
+    def get_trend_timeseries(self, data):
+        """Get the trend timeseries from the data."""
+        if not self._is_fit:
+            raise ValueError(
+                "The preprocessor has to be fit to data before the trend"
+                " timeseries can be requested."
+            )
+        if self._detrend is None:
+            raise ValueError("Detrending is set to `None`, so no trend is available")
+        if self._detrend == "linear":
+            return _get_lineartrend_timeseries(data, self.trend)
+        elif self._detrend == "polynomial":
+            return _get_polytrend_timeseries(data, self.trend)
+        raise ValueError(f"Unkown detrending method '{self._detrend}'")
 
     @property
     def trend(self) -> dict:

--- a/s2spy/preprocess.py
+++ b/s2spy/preprocess.py
@@ -5,6 +5,9 @@ from typing import Union
 import numpy as np
 import scipy.stats
 import xarray as xr
+import matplotlib.pyplot as plt
+import numpy as np
+import xarray as xr
 
 
 def _linregress(
@@ -78,19 +81,96 @@ def _subtract_linear_trend(data: Union[xr.DataArray, xr.Dataset], trend: dict):
     return data - trend["intercept"] - trend["slope"] * (data["time"].astype(float))
 
 
+def _subtract_polynomial_trend(
+    data: Union[xr.DataArray, xr.Dataset], trend: dict, degree: int = 2
+):
+    """Subtract a previously calculated polynomial trend from (new) data.
+
+    Args:
+        data: The data from which to subtract the trend (either an xarray DataArray or Dataset).
+        trend: A dictionary containing the polynomial trend coefficients.
+        degree: The degree of the polynomial that was used for the trend. Default is 2 for quadratic.
+
+    Returns:
+        The data with the polynomial trend subtracted.
+    """
+    # Ensure time dimension is treated as float for polynomial operations
+
+    # Calculate the polynomial trend values for each time point
+
+    data.coords["ordinal_day"] = (
+        ("time",),
+        (data.time - data.time.min()).values.astype("timedelta64[D]").astype(int),
+    )
+    coeffs = data.swap_dims({"time": "ordinal_day"}).polyfit("ordinal_day", deg=degree)
+
+    polynomial_trend = xr.polyval(
+        data.swap_dims({"time": "ordinal_day"})["ordinal_day"], trend["coefficients"]
+    ).swap_dims({"ordinal_day": "time"})
+
+    # Subtract the polynomial trend from the data
+    return (data - polynomial_trend).polyfit_coefficients
+
+
 def _get_trend(
-    data: Union[xr.DataArray, xr.Dataset], method: str, nan_mask: str = "complete"
+    data: Union[xr.DataArray, xr.Dataset],
+    method: str,
+    nan_mask: str = "complete",
+    degree=2,
 ):
     """Calculate the trend, with a certain method. Only linear is implemented."""
     if method == "linear":
         return _trend_linear(data, nan_mask)
+
+    if method == "polynomial":
+        # Calculate polynomial trend coefficients and store them.
+        return _trend_poly(data, degree, nan_mask)
     raise ValueError(f"Unkown detrending method '{method}'")
+
+
+def _trend_poly(
+    data: Union[xr.DataArray, xr.Dataset], degree: int = 2, nan_mask: str = "complete"
+) -> dict:
+    """Calculate the polynomial trend over time and return coefficients.
+
+    Args:
+        data: Input data.
+        degree: Degree of the polynomial for detrending.
+        nan_mask: How to handle NaN values.
+
+    Returns:
+        Dictionary containing polynomial trend coefficients.
+    """
+
+    # Mask NaNs in the data
+
+    if nan_mask == "individual":
+        mask = np.isnan(data)
+        data = data.where(~mask)
+    elif nan_mask == "complete":
+        if np.isnan(data).any():
+            return {"coefficients": np.nan}
+
+    data.coords["ordinal_day"] = (
+        ("time",),
+        (data.time - data.time.min()).values.astype("timedelta64[D]").astype(int),
+    )
+    coeffs = data.swap_dims({"time": "ordinal_day"}).polyfit("ordinal_day", deg=degree)
+
+    polynomial_trend = xr.polyval(
+        data.swap_dims({"time": "ordinal_day"})["ordinal_day"], coeffs
+    )
+    plt.plot(data.time, polynomial_trend.polyfit_coefficients)
+    plt.savefig("/tmp/test.png")
+    return {"coefficients": coeffs}
 
 
 def _subtract_trend(data: Union[xr.DataArray, xr.Dataset], method: str, trend: dict):
     """Subtract the previously calculated trend from (new) data. Only linear is implemented."""
     if method == "linear":
         return _subtract_linear_trend(data, trend)
+    if method == "polynomial":
+        return _subtract_polynomial_trend(data, trend)
     raise NotImplementedError
 
 

--- a/s2spy/preprocess.py
+++ b/s2spy/preprocess.py
@@ -12,6 +12,7 @@ def _linregress(x: np.ndarray, y: np.ndarray) -> tuple[float, float]:
 
     Used to make linregress more ufunc-friendly.
 
+
     Args:
         x: First array.
         y: Second array.

--- a/s2spy/rgdr/__init__.py
+++ b/s2spy/rgdr/__init__.py
@@ -1,2 +1,3 @@
 """Response Guided Dimensionality Reduction."""
+
 from . import label_alignment  # noqa: F401 (unused import)

--- a/s2spy/rgdr/label_alignment.py
+++ b/s2spy/rgdr/label_alignment.py
@@ -1,4 +1,5 @@
 """Label alignment tools for RGDR clusters."""
+
 import itertools
 import string
 from copy import copy

--- a/s2spy/rgdr/rgdr.py
+++ b/s2spy/rgdr/rgdr.py
@@ -1,4 +1,5 @@
 """Response Guided Dimensionality Reduction."""
+
 import warnings
 from os import linesep
 from typing import Optional
@@ -606,12 +607,12 @@ class RGDR:
         # Add the geographical centers for later alignment between, e.g., splits
         reduced_data = utils.geographical_cluster_center(data, reduced_data)
         # Include explanations about geographical centers as attributes
-        reduced_data.attrs[
-            "data"
-        ] = "Clustered data with Response Guided Dimensionality Reduction."
-        reduced_data.attrs[
-            "coordinates"
-        ] = "Latitudes and longitudes are geographical centers associated with clusters."
+        reduced_data.attrs["data"] = (
+            "Clustered data with Response Guided Dimensionality Reduction."
+        )
+        reduced_data.attrs["coordinates"] = (
+            "Latitudes and longitudes are geographical centers associated with clusters."
+        )
 
         # Remove the '0' cluster
         reduced_data = reduced_data.where(reduced_data["cluster_labels"] != 0).dropna(

--- a/s2spy/rgdr/utils.py
+++ b/s2spy/rgdr/utils.py
@@ -1,4 +1,5 @@
 """Commonly used utility functions for s2spy."""
+
 from typing import TypeVar
 import numpy as np
 import xarray as xr

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -258,7 +258,7 @@ class TestPreprocessor:
         indirect=True,
     )
     def test_fit_transform_da(self, preprocessor, raw_field):
-        
+
         raw_field = raw_field.to_array().squeeze("variable").drop_vars("variable")
         raw_field.name = "da_name"
         years = np.unique(raw_field.time.dt.year.values)
@@ -267,7 +267,12 @@ class TestPreprocessor:
         fit_transformed = preprocessor.fit_transform(train)
         transformed = preprocessor.transform(tranform_to)
         assert fit_transformed is not None
-        assert bool((fit_transformed.sel(time="2013-01-01") == transformed.sel(time="2013-01-01")).all())
+        assert bool(
+            (
+                fit_transformed.sel(time="2013-01-01")
+                == transformed.sel(time="2013-01-01")
+            ).all()
+        )
 
     @pytest.mark.parametrize(
         "preprocessor",
@@ -352,6 +357,15 @@ class TestPreprocessor:
         assert trend is not None
         assert trend.dims == raw_field.dims
         assert trend.sst.shape == raw_field.sst.shape
+
+        # get timeseries if single lat-lon point is seleted:
+        subset_latlon = raw_field.isel(latitude=[0], longitude=[0])
+        trend = preprocessor.get_trend_timeseries(
+            subset_latlon, align_coords=True
+        )
+        assert trend is not None
+        assert trend.dims == subset_latlon.dims
+        assert trend.sst.shape == subset_latlon.sst.shape        
 
     @pytest.mark.parametrize(
         "preprocessor",

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -237,20 +237,17 @@ class TestPreprocessor:
             detrend="linear",
             subtract_climatology=False,
         )
-        single_ts = raw_field["sst"].sel(time=raw_field["sst"].time.dt.dayofyear == 1)
-        single_ts[1, 0, 0] = np.nan
+        single_doy = raw_field["sst"].sel(time=raw_field["sst"].time.dt.dayofyear == 1)
+        single_doy[1, 0, 0] = np.nan
 
-        pp_field = prep.fit_transform(single_ts)
-        # assert np.equal(np.isnan(pp_field)["sst"][0, 0, 0], True)
-        assert (
-            np.isnan(pp_field).sum("time")[0, 0]
-            == np.unique(pp_field.time.dt.year).size
-        ), (
+        pp_field = prep.fit_transform(single_doy)
+        nans_in_pp_field = np.isnan(pp_field).sum("time")[0, 0]
+        assert int(nans_in_pp_field) == np.unique(pp_field.time.dt.year).size, (
             "If any NaNs are present in the data, "
             "the entire timeseries should have become completely NaN in the output."
         )
 
-        pp_field = prep.fit_transform(single_ts, dropna=True)
+        pp_field = prep.fit_transform(single_doy, dropna=True)
         assert np.isnan(pp_field).sum("time")[0, 0] == 1, (
             "If any NaNs are present in the data, "
             "the pp will only ignore those NaNs, but still fit a trendline."

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -1,4 +1,5 @@
 """Tests for the s2spy.preprocess module."""
+
 import numpy as np
 import pytest
 import scipy.signal
@@ -100,11 +101,12 @@ class TestPreprocessor:
     """Test preprocessor."""
 
     @pytest.fixture
-    def preprocessor(self):
+    def preprocessor(self, request):
+        method = request.param[0]
         prep = preprocess.Preprocessor(
             rolling_window_size=25,
             timescale="daily",
-            detrend="linear",
+            detrend=method,
             subtract_climatology=True,
         )
         return prep
@@ -158,6 +160,16 @@ class TestPreprocessor:
         )
         assert isinstance(prep, Preprocessor)
 
+    # pytest.mark.parametrize("preprocessor", ["linear", "polynomial"])
+
+    @pytest.mark.parametrize(
+        "preprocessor",
+        [
+            ("linear",),
+            ("polynomial",),
+        ],
+        indirect=True,
+    )
     def test_fit(self, preprocessor, raw_field):
         preprocessor.fit(raw_field)
         assert (
@@ -170,11 +182,27 @@ class TestPreprocessor:
             raw_field, timescale="daily"
         )
 
+    @pytest.mark.parametrize(
+        "preprocessor",
+        [
+            ("linear",),
+            ("polynomial",),
+        ],
+        indirect=True,
+    )
     def test_transform(self, preprocessor, raw_field):
         preprocessor.fit(raw_field)
         preprocessed_data = preprocessor.transform(raw_field)
         assert preprocessed_data is not None
 
+    @pytest.mark.parametrize(
+        "preprocessor",
+        [
+            ("linear",),
+            ("polynomial",),
+        ],
+        indirect=True,
+    )
     def test_transform_without_fit(self, preprocessor, raw_field):
         with pytest.raises(ValueError):
             preprocessor.transform(raw_field)
@@ -209,10 +237,26 @@ class TestPreprocessor:
 
         assert results == raw_field
 
+    @pytest.mark.parametrize(
+        "preprocessor",
+        [
+            ("linear",),
+            ("polynomial",),
+        ],
+        indirect=True,
+    )
     def test_fit_transform(self, preprocessor, raw_field):
         preprocessed_data = preprocessor.fit_transform(raw_field)
         assert preprocessed_data is not None
 
+    @pytest.mark.parametrize(
+        "preprocessor",
+        [
+            ("linear",),
+            ("polynomial",),
+        ],
+        indirect=True,
+    )
     def test_trend_property_not_fit(self, preprocessor):
         with pytest.raises(ValueError, match="The preprocessor has to be fit"):
             preprocessor.trend
@@ -222,6 +266,14 @@ class TestPreprocessor:
         with pytest.raises(ValueError, match="Detrending is set to `None`"):
             preprocessor_no_detrend.trend
 
+    @pytest.mark.parametrize(
+        "preprocessor",
+        [
+            ("linear",),
+            ("polynomial",),
+        ],
+        indirect=True,
+    )
     def test_climatology_property_not_fit(self, preprocessor):
         with pytest.raises(ValueError, match="The preprocessor has to be fit"):
             preprocessor.climatology
@@ -265,3 +317,38 @@ class TestPreprocessor:
             "the pp will only ignore those NaNs, but still fit a trendline."
             "Hence, the NaNs should remain the same in this case."
         )
+
+    @pytest.mark.parametrize(
+        "preprocessor",
+        [
+            ("linear",),
+            ("polynomial",),
+        ],
+        indirect=True,
+    )
+    def test_get_trendtimeseries_dataset(self, preprocessor, raw_field):
+        preprocessor.fit(raw_field)
+        trend = preprocessor.get_trend_timeseries(raw_field)
+        assert trend is not None
+        assert trend.dims == raw_field.dims
+        assert trend.sst.shape == raw_field.sst.shape
+
+    @pytest.mark.parametrize(
+        "preprocessor",
+        [
+            ("linear",),
+            ("polynomial",),
+        ],
+        indirect=True,
+    )
+    def test_get_trendtimeseries_dataarray(self, preprocessor, raw_field):
+        raw_field = raw_field.to_array().squeeze("variable")
+        preprocessor.fit(raw_field)
+        trend = preprocessor.get_trend_timeseries(raw_field)
+        assert trend is not None
+        assert (
+            trend.dims == raw_field.dims
+        ), f"dims do not match \n {trend.dims} \n {raw_field.dims}"
+        assert (
+            trend.shape == raw_field.shape
+        ), f"shape does not match \n {trend.shape} \n {raw_field.shape}"

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -239,8 +239,8 @@ class TestPreprocessor:
             nan_mask="complete",
         )
         single_doy = raw_field["sst"].sel(time=raw_field["sst"].time.dt.dayofyear == 1)
-        single_doy[0, 0, 0] = np.nan  # [0,0] lat/lon NaN at timestep 0
-        single_doy[1:, 1, 1] = np.nan  # [1:,1,1] lat/lon NaN at timestep 1:end
+        single_doy[:2, 0, 0] = np.nan  # [0,0] lat/lon NaN at timestep 0, 1
+        single_doy[2:, 1, 1] = np.nan  # [1:,1,1] lat/lon NaN at timestep 2:end
 
         pp_field = prep.fit_transform(single_doy)
         nans_in_pp_field = np.isnan(pp_field).sum("time")[0, 0]
@@ -258,7 +258,10 @@ class TestPreprocessor:
         )
 
         pp_field = prep.fit_transform(single_doy)
-        assert np.isnan(pp_field).sum("time")[0, 0] == 1, (
+        assert (
+            np.isnan(pp_field).sum("time") == np.isnan(single_doy).sum("time")
+        ).all(), (
             "If any NaNs are present in the data, "
             "the pp will only ignore those NaNs, but still fit a trendline."
+            "Hence, the NaNs should remain the same in this case."
         )

--- a/tests/test_preprocess.py
+++ b/tests/test_preprocess.py
@@ -235,7 +235,7 @@ class TestPreprocessor:
             rolling_window_size=1,
             timescale="daily",
             detrend="linear",
-            subtract_climatology=False,
+            subtract_climatology=True,
         )
         single_doy = raw_field["sst"].sel(time=raw_field["sst"].time.dt.dayofyear == 1)
         single_doy[1, 0, 0] = np.nan

--- a/tests/test_rgdr/test_rgdr.py
+++ b/tests/test_rgdr/test_rgdr.py
@@ -141,8 +141,8 @@ class TestCorrelation:
     def test_correlation(self, dummy_dataarray, dummy_timeseries):
         c_val, p_val = rgdr.correlation(dummy_dataarray, dummy_timeseries)
 
-        np.testing.assert_equal(c_val.values, 1)
-        np.testing.assert_equal(p_val.values, 0)
+        np.testing.assert_almost_equal(c_val.values, 1, decimal=7)
+        np.testing.assert_almost_equal(p_val.values, 0, decimal=7)
 
     def test_correlation_dim_name(self, dummy_dataarray, dummy_timeseries):
         da = dummy_dataarray.rename({"time": "i_interval"})

--- a/tests/test_rgdr/test_rgdr.py
+++ b/tests/test_rgdr/test_rgdr.py
@@ -1,4 +1,5 @@
 """Tests for the s2s.rgdr module."""
+
 import matplotlib
 import matplotlib.pyplot as plt
 import numpy as np

--- a/tests/test_rgdr/test_rgdr.py
+++ b/tests/test_rgdr/test_rgdr.py
@@ -149,8 +149,8 @@ class TestCorrelation:
         ts = dummy_timeseries.rename({"time": "i_interval"})
         c_val, p_val = rgdr.correlation(da, ts, corr_dim="i_interval")
 
-        np.testing.assert_equal(c_val.values, 1)
-        np.testing.assert_equal(p_val.values, 0)
+        np.testing.assert_almost_equal(c_val.values, 1, decimal=7)
+        np.testing.assert_almost_equal(p_val.values, 0, decimal=7)
 
     def test_correlation_wrong_target_dim_name(self, dummy_dataarray, dummy_timeseries):
         ts = dummy_timeseries.rename({"time": "dummy"})


### PR DESCRIPTION
In previous implementation the input dataarray when calling `get_trend_timeseries` was always the same shape as the initial data to which the preprocessor was fitted to.

But it is likely that one wants to reconstruct the trendline timeseries only the data with the same shape (the same as input lat lon shape).

This is now fixed in sub-optimal solution. Preferably the linear trend line gets stored in the same manner as the polyfit coefficients. 